### PR TITLE
feat: add Makefile, go.mod and replace deprecated linter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,11 @@
 # Test binary, built with `go test -c`
 *.test
 
-# Output of the go coverage tool, specifically when used with LiteIDE
-*.out
+# Output of the go coverage tool
+*.cov
 
 # Dependency directories (remove the comment below to include it)
-# vendor/
+vendor/
+
+# Binaries of any kind
+bin/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - godot
     - gofumpt
     - goimports
-    - golint
+    - revive
     - goprintffuncname
     - gosec
     - gosimple

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,57 @@
+# Makefile based on https://gist.github.com/thomaspoignant/5b72d579bd5f311904d973652180c705
+
+GOCMD=go
+GOTEST=$(GOCMD) test
+PROJECTNAME := $(shell basename "$(PWD)")
+BINARY_NAME?=$(PROJECTNAME)
+BIN_DIR?=bin
+TOOLS_DIR?=bin/tools
+
+GREEN  := $(shell tput -Txterm setaf 2)
+YELLOW := $(shell tput -Txterm setaf 3)
+WHITE  := $(shell tput -Txterm setaf 7)
+CYAN   := $(shell tput -Txterm setaf 6)
+RESET  := $(shell tput -Txterm sgr0)
+
+GOLANGCILINT_VERSION = 1.40.1
+
+.PHONY: all test build vendor
+
+all: help
+
+## Build:
+build: ## Build your project and put the output binary in out/bin/
+	mkdir -p $(BIN_DIR)
+	$(GOCMD) build -o out/bin/$(BINARY_NAME) .
+
+## Linting:
+lint: $(TOOLS_DIR)/golangci-lint ## Run linters
+	$(TOOLS_DIR)/golangci-lint run
+
+## Test:
+test: ## Run the tests of the project
+	$(GOTEST) -v -race ./...
+
+coverage: ## Run the tests of the project and export the coverage
+	$(GOTEST) -cover -covermode=count -coverprofile=profile.cov ./...
+	$(GOCMD) tool cover -func profile.cov
+
+## Help:
+help: ## Show this help.
+	@echo ''
+	@echo 'Usage:'
+	@echo '  ${YELLOW}make${RESET} ${GREEN}<target>${RESET}'
+	@echo ''
+	@echo 'Targets:'
+	@awk 'BEGIN {FS = ":.*?## "} { \
+		if (/^[a-zA-Z_-]+:.*?##.*$$/) {printf "    ${YELLOW}%-20s${GREEN}%s${RESET}\n", $$1, $$2} \
+		else if (/^## .*$$/) {printf "  ${CYAN}%s${RESET}\n", substr($$1,4)} \
+		}' $(MAKEFILE_LIST)
+$(BIN_DIR):
+	mkdir -p $(BIN_DIR)
+
+$(TOOLS_DIR):
+	mkdir -p $(TOOLS_DIR)
+
+$(TOOLS_DIR)/golangci-lint: $(TOOLS_DIR)
+	@wget -O - -q https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | BINDIR=$(@D) sh -s v$(GOLANGCILINT_VERSION) > /dev/null 2>&1

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 
 GOCMD=go
 GOTEST=$(GOCMD) test
-PROJECTNAME := $(shell basename "$(PWD)")
-BINARY_NAME?=$(PROJECTNAME)
+PROJECT_NAME := $(shell basename "$(PWD)")
+BINARY_NAME?=$(PROJECT_NAME)
 BIN_DIR?=bin
 TOOLS_DIR?=bin/tools
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/asyncapi/template-for-go-projects
+
+go 1.16


### PR DESCRIPTION
**Description**

This PR does the following:

- Adds a `go.mod` file so our GH workflows can run CI, as it is based on the presence of this file.
- Adds a standard `Makefile` with basic targets such as `build`, `lint` and `test`, among others.
- Adds `vendor/` and `.cov` to the `.gitignore` file.
- Replaces deprecated `golint` linter by `revive`.

**Related issue**

https://github.com/asyncapi/shape-up-process/issues/94