### PR TITLE
fix: change bin output dir to match .gitignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,9 +20,9 @@ GOLANGCILINT_VERSION = 1.40.1
 all: help
 
 ## Build:
-build: ## Build your project and put the output binary in out/bin/
+build: ## Build your project and put the output binary in bin/out
 	mkdir -p $(BIN_DIR)
-	$(GOCMD) build -o out/bin/$(BINARY_NAME) .
+	$(GOCMD) build -o bin/out/$(BINARY_NAME) .
 
 ## Linting:
 lint: $(TOOLS_DIR)/golangci-lint ## Run linters


### PR DESCRIPTION
As you can see in https://github.com/asyncapi/template-for-go-projects/blob/master/.gitignore#L18, the bin folder is `bin` so this PR changes the go app binary output dir from `out/bin` to `bin/out` so it matches with the `.gitignore` file.