### PR TITLE
feat: disable funlen linter for all tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -45,3 +45,9 @@ linters-settings:
   forbidigo:
     forbid:
       - fmt.Print.* # usually just used for debugging purpose
+      
+issues:
+  exclude-rules:
+    - path: _test.go
+      linters:
+        - funlen


### PR DESCRIPTION
**Description**

`funlen` linters complain when a function name is "too long". This is pretty cool but tests usually have long function names by convention.

This change disables `funlen` linter for go tests.